### PR TITLE
feat(ui): render all available groups in explore route Data hooks

### DIFF
--- a/src/components/customer/ui/group-card.tsx
+++ b/src/components/customer/ui/group-card.tsx
@@ -14,8 +14,11 @@ import {
 import { CurrencyNgn, ArrowRight } from "@phosphor-icons/react";
 import { StackedAvatars } from "./stacked-avatars";
 import { useNavigate } from "@tanstack/react-router";
+import { MyGroupCardProps } from "./my-group-card";
+import { dicebear } from "@utils/misc";
+import { bgs, randomBg } from "@utils/constants";
 
-interface GroupCardProps {
+interface GroupCardProps extends Pick<MyGroupCardProps, "data"> {
   bgColor?: string;
   cardGradient?: string;
   hasGradient?: boolean;
@@ -25,14 +28,6 @@ interface GroupCardProps {
   groupType: "suggested" | "available";
 }
 
-const avatars = [
-  "/img/person-1.svg",
-  "/img/person-2.svg",
-  "/img/person-3.svg",
-  "/img/person-4.svg",
-  "/img/person-1.svg",
-  "/img/person-4.svg",
-];
 const bgGradient = [
   "/img/frame-1.svg",
   "/img/frame-2.svg",
@@ -49,6 +44,7 @@ export const GroupCard = ({
   width,
   height,
   link,
+  data,
   groupType = "suggested",
 }: GroupCardProps) => {
   const getNextGradient = () => {
@@ -58,6 +54,10 @@ export const GroupCard = ({
   };
   const gradient = getNextGradient();
   const navigate = useNavigate();
+  const avatars = data?.participants?.map((member, index) => {
+    const memberBg = bgs[index % bgs.length];
+    return `${member.customer?.profilePicture || `${dicebear}?seed=${member?.customer?.name}&size=48&flip=true&backgroundColor=${memberBg}`}`
+  });
 
   return (
     <Card
@@ -91,14 +91,18 @@ export const GroupCard = ({
                 color={hasGradient ? "#ffffff" : "#000000"}
                 textTransform="capitalize"
               >
-                Delight Saver
+                {data?.name && data?.name?.length < 15
+                  ? data?.name
+                  : `${data.name?.substring(0, 16)}...`}
               </Text>
               <HStack spacing="3px" mt="2px">
                 <Flex
                   height="25px"
                   borderRadius="18px"
                   px="1em"
-                  bg={hasGradient ? "rgba(255, 255, 255, 0.2)" : "var(--grey-007)"}
+                  bg={
+                    hasGradient ? "rgba(255, 255, 255, 0.2)" : "var(--grey-007)"
+                  }
                   alignItems="center"
                 >
                   <CurrencyNgn
@@ -112,13 +116,22 @@ export const GroupCard = ({
                     fontWeight="medium"
                     color={hasGradient ? "#ffffff" : "var(--text-1)"}
                   >
-                    10,000/week
+                    {data.contributionAmount}/{data.contributionFrequency}
                   </Text>
                 </Flex>
               </HStack>
             </Box>
             <Box w="full">
-              <StackedAvatars images={avatars} maxVisible={3} />
+              {avatars?.length === 0 ? (
+                <Text
+                  fontSize="12px"
+                  color={hasGradient ? "#fff" : "var(--grey)"}
+                >
+                  {avatars?.length} members
+                </Text>
+              ) : (
+                <StackedAvatars images={avatars} maxVisible={3} />
+              )}
             </Box>
             <Box w="full">
               <Text
@@ -133,7 +146,7 @@ export const GroupCard = ({
                 fontSize={{ base: "14px", lg: "18px" }}
                 color={hasGradient ? "#ffffff" : "var(--text-1)"}
               >
-                24th Nov 2025
+                {data.startDate}
               </Text>
             </Box>
           </Flex>
@@ -162,6 +175,9 @@ export const GroupCard = ({
                 fontFamily="var(--poppins)"
                 fontWeight="regular"
                 fontSize="12px"
+                _hover={{
+                  background: hasGradient ? "#fff" : "var(--main)",
+                }}
                 color={hasGradient ? "#4f4f4f" : "var(--text-2)"}
               >
                 Share
@@ -188,7 +204,7 @@ export const GroupCard = ({
                     color={hasGradient ? "#ffffff" : "var(--main)"}
                     fontWeight="bold"
                   >
-                    100,000
+                    {data.payOutAmount}
                   </Text>
                 </HStack>
               </Box>
@@ -217,7 +233,9 @@ export const GroupCard = ({
                   ? "rgba(255, 255, 255, 0.3)"
                   : "var(--btn-secondary-7)",
               }}
-              onClick={() => navigate({ to: `/dashboard/explore/${link}` })}
+              onClick={() =>
+                navigate({ to: `/dashboard/explore/${data.groupID}` })
+              }
             >
               <Text color={groupType === "suggested" ? "#fff" : "var(--main)"}>
                 Join

--- a/src/components/customer/ui/group-card.tsx
+++ b/src/components/customer/ui/group-card.tsx
@@ -98,7 +98,7 @@ export const GroupCard = ({
                   height="25px"
                   borderRadius="18px"
                   px="1em"
-                  bg={hasGradient ? "rgba(255, 255, 255, 0.2)" : "#81818112"}
+                  bg={hasGradient ? "rgba(255, 255, 255, 0.2)" : "var(--grey-007)"}
                   alignItems="center"
                 >
                   <CurrencyNgn

--- a/src/components/customer/ui/my-group-card.tsx
+++ b/src/components/customer/ui/my-group-card.tsx
@@ -17,7 +17,7 @@ import { Group } from "@utils/types";
 import { randomBg } from "@utils/constants";
 import { dicebear } from "@utils/misc";
 
-interface MyGroupCardProps extends Partial<ChakraProps> {
+export interface MyGroupCardProps extends Partial<ChakraProps> {
   bgColor?: string;
   data: Partial<Group>;
   acceptanceStatus?: GlobalStatus;

--- a/src/components/customer/ui/my-group-card.tsx
+++ b/src/components/customer/ui/my-group-card.tsx
@@ -32,7 +32,7 @@ export const MyGroupCard = ({
   const groupData = data;
   const groupMembersAvatar = groupData?.participants?.map(
     (members) =>
-      `${members.customer.profilePicture || `${dicebear}?seed=${members.customer.name}&size=48&flip=true&background=${randomBg}`}`,
+      `${members.customer?.profilePicture || `${dicebear}?seed=${members?.customer?.name}&size=48&flip=true&background=${randomBg}`}`,
   );
 
   return (
@@ -44,6 +44,7 @@ export const MyGroupCard = ({
       rounded="10px"
       position="relative"
       bg={bgColor || "#ffffff"}
+      _hover={{ cursor: "pointer" }}
       {...props}
     >
       <CardBody px={{ lg: "1em", md: ".8em", base: ".6em" }} py="23px" w="full">
@@ -70,7 +71,7 @@ export const MyGroupCard = ({
                   rounded="full"
                   px={{ lg: ".8em", base: ".4em", md: ".6em" }}
                   py={1}
-                  bg="#81818112"
+                  bg="var(--grey-007)"
                   alignItems="center"
                 >
                   <CurrencyNgn size={16} weight="bold" color="var(--text-1)" />
@@ -85,27 +86,20 @@ export const MyGroupCard = ({
                     {groupData?.contributionFrequency}
                   </Text>
                 </Flex>
-                <Flex
-                  rounded="full"
-                  px={4}
-                  py={1}
-                  bg="#81818112"
-                  alignItems="center"
-                >
+                <HStack gap=".2em" px={2} rounded="full" py={1} bg="var(--grey-007)" alignItems="center">
                   <RefreshCcw
                     size={16}
                     strokeWidth={2.5}
                     color="var(--text-1)"
                   />
                   <Text
-                    as="p"
                     fontSize={{ base: "12px", lg: "14px" }}
                     fontWeight="400"
                     color="var(--main)"
                   >
                     {groupData?.numberOfcircle}
                   </Text>
-                </Flex>
+                </HStack>
               </HStack>
               <Box w="full" mt="28px">
                 {groupMembersAvatar?.length === 0 ? (
@@ -122,7 +116,7 @@ export const MyGroupCard = ({
               <Box w="fit-content">
                 <Text
                   fontSize={{ base: "12px", lg: "14px" }}
-                  fontWeight="medium"
+                  fontWeight="400"
                   color="var(--grey)"
                   textAlign="end"
                 >
@@ -149,7 +143,7 @@ export const MyGroupCard = ({
 
               <Box w="fit-content">
                 <Text
-                  fontSize={{ base: "12px", lg: "18px" }}
+                  fontSize={{ base: "12px", lg: "14px" }}
                   fontWeight="400"
                   color="var(--grey)"
                   textAlign="end"

--- a/src/components/customer/ui/payment-card.tsx
+++ b/src/components/customer/ui/payment-card.tsx
@@ -41,7 +41,7 @@ export const PaymentCard = ({
           <Flex flexDirection="column" alignContent="center">
             <Text
               fontWeight="400"
-              fontSize={{ base: "14px", lg: "18px" }}
+              fontSize={{ base: "14px", xl: "18px", lg: "14px" }}
               color="var(--text-1)"
             >
               {`${dateArray?.[1]} - ${dateArray?.[2]}` || "November - 2025"}

--- a/src/components/customer/ui/stacked-avatars.tsx
+++ b/src/components/customer/ui/stacked-avatars.tsx
@@ -1,4 +1,4 @@
-import { Flex, Image, Box, Text } from "@chakra-ui/react";
+import { Avatar, AvatarGroup, Flex, Box, Text } from "@chakra-ui/react";
 
 interface StackedAvatarsProps {
   images: string[] | undefined;
@@ -9,25 +9,29 @@ export const StackedAvatars = ({
   images,
   maxVisible = 3,
 }: StackedAvatarsProps) => {
-  const visibleImages = images?.slice(0, maxVisible);
-  const remainingCount = images && images?.length - maxVisible;
+  if (!images || images.length === 0) return null;
+
+  const visibleImages = images.slice(0, maxVisible);
+  const remainingCount = images.length - maxVisible;
 
   return (
-    <Flex>
-      {visibleImages?.map((src, index) => (
-        <Image
-          key={index}
-          src={src}
-          boxSize="35px"
-          rounded="full"
-          shadow="sm"
-          objectFit="cover"
-          border="2px solid white"
-          ml={index === 0 ? "0" : "-12px"}
-        />
-      ))}
+    <Flex alignItems="center">
+      <AvatarGroup
+        spacing="-12px"
+        max={maxVisible}
+      >
+        {visibleImages.map((src, index) => (
+          <Avatar
+            key={index}
+            src={src}
+            border="2px solid white"
+            boxShadow="sm"
+            boxSize="38px"
+          />
+        ))}
+      </AvatarGroup>
 
-      {remainingCount && remainingCount > 0 && (
+      {remainingCount > 0 && (
         <Box
           boxSize="38px"
           display="flex"

--- a/src/containers/app/explore/index.tsx
+++ b/src/containers/app/explore/index.tsx
@@ -15,6 +15,7 @@ import { schema } from "@utils/validators";
 import { useMobileScreens } from "@hooks/mobile-screen";
 import { FunnelSimple } from "@phosphor-icons/react";
 import { ExploreFilter } from "@layouts/modal-layout/explore-filter";
+import { useAllGroups } from "@hooks/swr";
 
 const initialValues = {
   members: "",
@@ -25,6 +26,7 @@ const initialValues = {
 
 export const Explore = () => {
   const { isMobile } = useMobileScreens();
+  const { data, isLoading } = useAllGroups();
   const [isMobileFilter, setIsMobileFilter] = useState(false);
 
   return (
@@ -32,7 +34,6 @@ export const Explore = () => {
       <Text as="p" fontSize="24px" color="var(--text-1)" mb="0.5rem">
         Suggested for you
       </Text>
-
       <Box
         width="100%"
         maxWidth={{ lg: "1360px", "2xl": "100%" }}
@@ -45,18 +46,18 @@ export const Explore = () => {
           cursor: "grab",
         }}
       >
-        {Array.from({ length: 5 }).map((_, index: React.Key) => {
+        {data?.slice(0, 4)?.map((group, index: React.Key) => {
           return (
             <GroupCard
               groupType="suggested"
               hasGradient
               link="my-group"
               key={index}
+              data={group}
             />
           );
         })}
       </Box>
-
       <Box
         mt="1em"
         w="100%"
@@ -168,9 +169,9 @@ export const Explore = () => {
         width="100%"
         mt="17px"
       >
-        {Array.from({ length: 5 }).map((_, index) => (
+        {data?.map((group, index) => (
           <Box minHeight="240px" flex={1} key={index}>
-            <GroupCard groupType="available" />
+            <GroupCard groupType="available" data={group} />
           </Box>
         ))}
       </SimpleGrid>

--- a/src/containers/app/groups/index.tsx
+++ b/src/containers/app/groups/index.tsx
@@ -16,6 +16,8 @@ import {
   TabPanels,
   TabPanel,
   Stack,
+  Center,
+  Spinner,
 } from "@chakra-ui/react";
 import { MyGroupCard, PaymentCard, Calendar } from "@components/customer/ui";
 import { Icon } from "@components/icon";
@@ -36,7 +38,7 @@ export const GROUPS_TAB_ITEMS = [
 
 export const Groups = () => {
   const { isMobile } = useMobileScreens();
-  const { data } = useMyGroups();
+  const { data, isLoading } = useMyGroups();
 
   return (
     <Flex
@@ -62,7 +64,7 @@ export const Groups = () => {
           />
           <Text
             fontWeight="400"
-            fontSize={{ base: "14px", lg: "16px" }}
+            fontSize={{ base: "14px", lg: "14px", xl: "16px", md: "14px" }}
             color="var(--white-fade)"
           >
             Complete{" "}
@@ -103,67 +105,34 @@ export const Groups = () => {
               })}
             </TabList>
 
-            <TabPanels>
-              <TabPanel px="0px" pt="1.4em">
-                <Stack direction="column" gap=".8em">
-                  {data?.map((group, index) => {
-                    return (
-                      <MyGroupCard
-                        key={group.id}
-                        data={group}
-                        bgColor={index === 0 ? "var(--card-bg-active)" : ""}
-                        border={`0.5px solid ${index === 0 ? "var(--primary)" : "var(--border-muted)"}`}
-                      />
-                    );
-                  })}
-                </Stack>
-              </TabPanel>
-            </TabPanels>
+            {isLoading ? (
+              <Center height="450px">
+                <Spinner size="sm" color="var(--grey)" />
+              </Center>
+            ) : (
+              <TabPanels>
+                <TabPanel px="0px" pt="1.4em">
+                  <Stack direction="column" gap=".8em">
+                    {data?.map((group, index) => {
+                      return (
+                        <MyGroupCard
+                          key={group.id}
+                          data={group}
+                          bgColor={index === 0 ? "var(--card-bg-active)" : ""}
+                          border={`0.5px solid ${index === 0 ? "var(--primary)" : "var(--border-muted)"}`}
+                        />
+                      );
+                    })}
+                  </Stack>
+                </TabPanel>
+              </TabPanels>
+            )}
           </Tabs>
-
-          <Menu autoSelect={false}>
-            <MenuButton
-              as={Button}
-              rightIcon={<ChevronDown color="var(--grey)" size={14} />}
-              px="1.35rem"
-              py="8px"
-              rounded="3xl"
-              fontSize={{ base: "12px", lg: "14px" }}
-              fontWeight="400"
-              color="#040404"
-              background="var(--grey-100)"
-              display={{ base: "block", md: "none" }}
-              _active={{
-                background: "var(--grey-100)",
-              }}
-            >
-              All groups
-            </MenuButton>
-            <MenuList px=".4em" py=".4em">
-              {GROUPS_TAB_ITEMS.map((tab) => {
-                return (
-                  <MenuItem
-                    my=".2em"
-                    key={tab.id}
-                    _hover={{
-                      background: "var(--grey-100)",
-                    }}
-                    transition="all .3s ease-out"
-                    borderRadius="4px"
-                    fontSize="12px"
-                  >
-                    {tab.name}
-                  </MenuItem>
-                );
-              })}
-            </MenuList>
-          </Menu>
         </Box>
       </Box>
 
-      <VStack
-        width={{ lg: "35%", md: "45%", base: "100%" }}
-        spacing="2px"
+      <Box
+        width={{ lg: "48%", xl: "35%", md: "45%", base: "100%" }}
         position="sticky"
         top="80px"
       >
@@ -200,7 +169,7 @@ export const Groups = () => {
         <Box maxHeight="127px" width="full">
           <PaymentCard deadlineDate="24-December-2025" dateType="Missed date" />
         </Box>
-      </VStack>
+      </Box>
     </Flex>
   );
 };

--- a/src/containers/app/groups/index.tsx
+++ b/src/containers/app/groups/index.tsx
@@ -22,7 +22,7 @@ import {
 import { MyGroupCard, PaymentCard, Calendar } from "@components/customer/ui";
 import { Icon } from "@components/icon";
 import { useMobileScreens } from "@hooks/mobile-screen";
-import { useMyGroups } from "@hooks/swr";
+import { useAllGroups } from "@hooks/swr";
 import { ChevronDown } from "lucide-react";
 import slugify from "slugify";
 
@@ -38,7 +38,7 @@ export const GROUPS_TAB_ITEMS = [
 
 export const Groups = () => {
   const { isMobile } = useMobileScreens();
-  const { data, isLoading } = useMyGroups();
+  const { data, isLoading } = useAllGroups();
 
   return (
     <Flex

--- a/src/hooks/swr/groups.ts
+++ b/src/hooks/swr/groups.ts
@@ -1,5 +1,6 @@
 import { getAllGroups, getJoinedGroups } from "@queries/groups";
 import { swrOptions } from "@utils/constants";
+import { dicebear } from "@utils/misc";
 import useSWR, { mutate } from "swr";
 
 export const useJoinedGroups = () => {
@@ -20,7 +21,7 @@ export const useJoinedGroups = () => {
 };
 
 
-export const useMyGroups = () => {
+export const useAllGroups = () => {
   const key = "my-groups";
   const { data, error, isLoading } = useSWR(
     key,

--- a/src/layouts/app-layout/index.tsx
+++ b/src/layouts/app-layout/index.tsx
@@ -28,7 +28,6 @@ export const AppLayout = ({ children, routeTitle }: AppLayoutProps) => {
         <AppHeader routeTitle={routeTitle} />
         <Box
           pt="1.4em"
-          border="1px solid red"
           px={{ base: ".6em", "2xl": "2em", xl: "1em", lg: ".8em" }}
         >
           {children}

--- a/src/layouts/app-layout/index.tsx
+++ b/src/layouts/app-layout/index.tsx
@@ -28,6 +28,7 @@ export const AppLayout = ({ children, routeTitle }: AppLayoutProps) => {
         <AppHeader routeTitle={routeTitle} />
         <Box
           pt="1.4em"
+          border="1px solid red"
           px={{ base: ".6em", "2xl": "2em", xl: "1em", lg: ".8em" }}
         >
           {children}

--- a/src/layouts/app-layout/sidebar.tsx
+++ b/src/layouts/app-layout/sidebar.tsx
@@ -84,6 +84,7 @@ const consoleNavBase = [
   },
   { iconBaseName: "user", name: "Users", path: "/console/users" },
 ];
+
 export const Sidebar = () => {
   const pathname = useCurrentPath();
   const isConsoleRoute = useConsolePath();
@@ -288,10 +289,10 @@ export const Sidebar = () => {
                     listStyleType="none"
                     display="flex"
                     alignItems="center"
-                    px="1.4em"
+                    px={{ "2xl": "1.4em", xl: "1em", lg: "1em" }}
                     height="54px"
                     borderRadius="8px"
-                    gap={{ "2xl": "1.4em", xl: "1em", lg: "1em" }}
+                    gap={{ "2xl": "1.4em", xl: ".6em", lg: "1em" }}
                     textTransform="capitalize"
                     color="#fff"
                     background={

--- a/src/style/_variables.scss
+++ b/src/style/_variables.scss
@@ -33,6 +33,7 @@
   --border-muted: #8181816b;
   --calendar-days-color: #696969;
   --grey-sec: #42545f;
+  --grey-007: #81818112;
 
   --success-700: #027a48;
   --success-25: #f6fef9;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -47,7 +47,7 @@ export type State =
   | "success"
   | "deleting";
 
-const bgs = ["b6e3f4", "c0aede", "d1d4f9", "ffd5dc", "ffdfbf"];
+export const bgs = ["b6e3f4", "c0aede", "d1d4f9", "ffd5dc", "ffdfbf"];
 const randomBgIndex = Math.floor(Math.random() * bgs.length);
 export const randomBg = bgs[randomBgIndex];
 


### PR DESCRIPTION
- refactor the stacked avatar component to use `Avatar` from Chakra
- Show different bgs for each avatar dynamically
- truncated group name if it exceeds a certain character limit